### PR TITLE
Fix: Remove stray "0" in Overall Weight Statistics

### DIFF
--- a/apps/web/src/components/dashboard/Stats.tsx
+++ b/apps/web/src/components/dashboard/Stats.tsx
@@ -55,7 +55,7 @@ const Stats = () => {
               )}
             </>
           ))}
-        {showCalories && ppw && ppw <= 0 && (
+        {showCalories && ppw !== undefined && ppw <= 0 && (
           <>
             <li className="mt-4">
               {isMe ? "You are" : "They are"} burning <strong>{formatNumber(caloriesPerDay)} cal/day</strong> {weightSlope > 0 ? "less" : "more"} than{" "}


### PR DESCRIPTION
**Problem:** 
A "0" was being rendered at the bottom of my "Overall Weight Statistics" section.

**Root Cause:**
When `ppw` is `0`, the expression `true && 0 && true` evaluates to `0`. React renders the number `0` as the string "0" instead of hiding the section.

**Fix:**
Changed the truthy check to an explicit `undefined` check, ensuring the expression evaluates to `true/false` instead of a number.

**Examples**
<img width="417" height="181" alt="Screenshot 2025-07-24 at 11 09 02 PM" src="https://github.com/user-attachments/assets/56ef8d87-f1ce-40b5-b79e-1b9944e8fada" />
<img width="852" height="329" alt="Screenshot 2025-07-24 at 11 33 30 PM" src="https://github.com/user-attachments/assets/31aedc3f-16b6-4975-9288-89f7dfdf2340" />


P.S. Thanks for fixing up Trendweight, I use it every day! ❤️ Happy to fix a thing and contribute a bit
