### PR TITLE
fix(goals): Allow setting goals to 1dp

### DIFF
--- a/apps/web/src/components/settings/goal-section.tsx
+++ b/apps/web/src/components/settings/goal-section.tsx
@@ -52,7 +52,7 @@ export function GoalSection({ register, errors, watch, control }: GoalSectionPro
           <Input
             id="goalWeight"
             type="number"
-            step="0.1"
+            step="any"
             {...register("goalWeight", {
               valueAsNumber: true,
               min: { value: 0, message: "Goal weight must be positive" },

--- a/apps/web/src/components/settings/goal-section.tsx
+++ b/apps/web/src/components/settings/goal-section.tsx
@@ -52,7 +52,7 @@ export function GoalSection({ register, errors, watch, control }: GoalSectionPro
           <Input
             id="goalWeight"
             type="number"
-            step="1"
+            step="0.1"
             {...register("goalWeight", {
               valueAsNumber: true,
               min: { value: 0, message: "Goal weight must be positive" },


### PR DESCRIPTION
I currently have an arbitrary goal of dipping below a certain BMI, to make the "goal range" on the graph appear where I want it, I need to provide a more accurate goal weight than is currently available. Client side validation fails when you provide 1 decimal place as it uses step="1" on the input. 

I tested this change by making a manual PUT profile requests, and also by editing the live html in dev tools to allow step="0.1", which allowed me to save my profile and things worked as expected.

There's actually a test that validates "should allow typing in goal weight field" with 145.5 pounds, so it seems like the intent was to allow decimal values, it's just the client side validation on saving that stops you.

Feel free to close the PR if you don't want the "feature", I can work around it by manually editing the HTML anyways :) 

Thanks for your work, trendweight is incredibly useful and motivating

<img width="562" height="143" alt="image" src="https://github.com/user-attachments/assets/a9fc961d-dd80-44e7-8233-50fe8b111a12" />

<img width="358" height="129" alt="image" src="https://github.com/user-attachments/assets/87bf7d5e-4180-4b76-a213-e197744cd067" />
