### PR TITLE
fix: correct Dowloading to Downloading typo in MeasurementSyncService.cs

### DIFF
--- a/apps/api/TrendWeight/Features/Measurements/MeasurementSyncService.cs
+++ b/apps/api/TrendWeight/Features/Measurements/MeasurementSyncService.cs
@@ -102,7 +102,7 @@ public class MeasurementSyncService : IMeasurementSyncService
                 // Start progress reporting if we have a reporter
                 if (_progressReporter != null)
                 {
-                    await _progressReporter.ReportSyncProgressAsync("running", "Dowloading data from providers...");
+                    await _progressReporter.ReportSyncProgressAsync("running", "Downloading data from providers...");
                 }
 
                 var refreshResults = await Task.WhenAll(refreshTasks);


### PR DESCRIPTION
## Summary
Corrected "Dowloading" to "Downloading" typo in MeasurementSyncService.cs line 105.

## Changes
- apps/api/TrendWeight/Features/Measurements/MeasurementSyncService.cs:105

## Testing
- Syntax check passed (C# file, single string change)

Fixes #447