### PR TITLE
feat: optional alternate trend algorithms (Holt's linear trend method)

### DIFF
--- a/apps/api/TrendWeight.Tests/Features/Measurements/Services/MeasurementComputationServiceTests.cs
+++ b/apps/api/TrendWeight.Tests/Features/Measurements/Services/MeasurementComputationServiceTests.cs
@@ -12,14 +12,15 @@ public class MeasurementComputationServiceTests
 
     #region Test Data Helpers
 
-    private static ProfileData CreateTestProfile(int dayStartOffset = 0, bool hideDataBeforeStart = false, DateTime? goalStart = null)
+    private static ProfileData CreateTestProfile(int dayStartOffset = 0, bool hideDataBeforeStart = false, DateTime? goalStart = null, string? trendAlgorithm = null)
     {
         return new ProfileData
         {
             UseMetric = true,
             DayStartOffset = dayStartOffset,
             HideDataBeforeStart = hideDataBeforeStart,
-            GoalStart = goalStart
+            GoalStart = goalStart,
+            TrendAlgorithm = trendAlgorithm
         };
     }
 
@@ -531,6 +532,194 @@ public class MeasurementComputationServiceTests
         result.Should().HaveCount(2);
         // Note: The service doesn't preserve source in ComputedMeasurement model
         // This test documents the current behavior
+    }
+
+    #endregion
+
+    #region Trend Algorithm Preset Tests
+
+    [Fact]
+    public void ComputeMeasurements_WithHoltPreset_CalculatesCorrectTrend()
+    {
+        // Arrange
+        var profile = CreateTestProfile(trendAlgorithm: "holt"); // alpha = 0.1, beta = 0.1
+        var sourceData = CreateTestSourceData(
+            ("2024-01-01", "08:00:00", 70.0m, null),
+            ("2024-01-02", "08:00:00", 71.0m, null),
+            ("2024-01-03", "08:00:00", 69.0m, null),
+            ("2024-01-04", "08:00:00", 70.0m, null)
+        );
+
+        // Act
+        var result = _sut.ComputeMeasurements(sourceData, profile);
+
+        // Assert
+        result.Should().HaveCount(4);
+
+        // First measurement: level = actual, slope = 0
+        result[0].TrendWeight.Should().Be(70.0m);
+
+        // Second: forecast = 70.0 + 0 = 70.0
+        //         level = 70.0 + 0.1 * (71.0 - 70.0) = 70.1
+        //         slope = 0 + 0.1 * (70.1 - 70.0 - 0) = 0.01
+        result[1].TrendWeight.Should().Be(70.1m);
+
+        // Third:  forecast = 70.1 + 0.01 = 70.11
+        //         level = 70.11 + 0.1 * (69.0 - 70.11) = 69.999
+        //         slope = 0.01 + 0.1 * (69.999 - 70.1 - 0.01) = -0.0011
+        result[2].TrendWeight.Should().Be(69.999m);
+
+        // Fourth: forecast = 69.999 - 0.0011 = 69.9979
+        //         level = 69.9979 + 0.1 * (70.0 - 69.9979) = 69.99811 -> rounds to 69.998
+        result[3].TrendWeight.Should().Be(69.998m);
+    }
+
+    [Fact]
+    public void ComputeMeasurements_WithHoltPreset_CalculatesCorrectFatTrends()
+    {
+        // Arrange
+        var profile = CreateTestProfile(trendAlgorithm: "holt"); // alpha = 0.1, beta = 0.1
+        var sourceData = CreateTestSourceData(
+            ("2024-01-01", "08:00:00", 70.0m, 0.25m),
+            ("2024-01-02", "08:00:00", 71.0m, 0.26m),
+            ("2024-01-03", "08:00:00", 69.0m, 0.24m)
+        );
+
+        // Act
+        var result = _sut.ComputeMeasurements(sourceData, profile);
+
+        // Assert
+        result.Should().HaveCount(3);
+
+        // Fat ratio Holt series: 0.25; then 0.25 + 0.1 * (0.26 - 0.25) = 0.251, slope = 0.0001;
+        // then forecast = 0.2511, level = 0.2511 + 0.1 * (0.24 - 0.2511) = 0.24999 -> rounds to 0.25
+        result[0].TrendFatPercent.Should().Be(0.25m);
+        result[1].TrendFatPercent.Should().Be(0.251m);
+        result[2].TrendFatPercent.Should().Be(0.25m);
+
+        // Fat mass series (weight * fatRatio): 17.5, 18.46, 16.56
+        // Holt: 17.5; then 17.5 + 0.1 * (18.46 - 17.5) = 17.596, slope = 0.0096;
+        // then forecast = 17.6056, level = 17.6056 + 0.1 * (16.56 - 17.6056) = 17.50104 -> 17.501
+        result[0].TrendFatMass.Should().Be(17.5m);
+        result[1].TrendFatMass.Should().Be(17.596m);
+        result[2].TrendFatMass.Should().Be(17.501m);
+
+        // Lean mass series (weight * (1 - fatRatio)): 52.5, 52.54, 52.44
+        // Holt: 52.5; then 52.5 + 0.1 * (52.54 - 52.5) = 52.504, slope = 0.0004;
+        // then forecast = 52.5044, level = 52.5044 + 0.1 * (52.44 - 52.5044) = 52.49796 -> 52.498
+        result[0].TrendLeanMass.Should().Be(52.5m);
+        result[1].TrendLeanMass.Should().Be(52.504m);
+        result[2].TrendLeanMass.Should().Be(52.498m);
+    }
+
+    [Theory]
+    [InlineData("default")]
+    [InlineData("bogus-future-algorithm")]
+    public void ComputeMeasurements_WithDefaultOrUnknownPreset_MatchesDefaultExactly(string trendAlgorithm)
+    {
+        // Arrange: a deterministic pseudo-random series
+        var random = new Random(396);
+        var measurements = new List<(string date, string time, decimal weight, decimal? fatRatio)>();
+        for (int i = 0; i < 100; i++)
+        {
+            var date = new DateTime(2024, 1, 1).AddDays(i).ToString("yyyy-MM-dd");
+            var weight = 80.0m - 0.05m * i + (decimal)random.NextDouble();
+            measurements.Add((date, "08:00:00", Math.Round(weight, 2), 0.2m + 0.001m * (i % 10)));
+        }
+        var sourceData = CreateTestSourceData(measurements.ToArray());
+
+        // Act
+        var defaultResult = _sut.ComputeMeasurements(sourceData, CreateTestProfile());
+        var presetResult = _sut.ComputeMeasurements(sourceData, CreateTestProfile(trendAlgorithm: trendAlgorithm));
+
+        // Assert: explicit "default" and unknown ids are exactly the default algorithm
+        presetResult.Should().HaveCount(defaultResult.Count);
+        for (int i = 0; i < defaultResult.Count; i++)
+        {
+            presetResult[i].TrendWeight.Should().Be(defaultResult[i].TrendWeight);
+            presetResult[i].TrendFatPercent.Should().Be(defaultResult[i].TrendFatPercent);
+            presetResult[i].TrendFatMass.Should().Be(defaultResult[i].TrendFatMass);
+            presetResult[i].TrendLeanMass.Should().Be(defaultResult[i].TrendLeanMass);
+        }
+    }
+
+    [Fact]
+    public void ComputeMeasurements_DefaultProfile_MatchesReferenceEmaLoop()
+    {
+        // Arrange: deterministic pseudo-random weights
+        var random = new Random(42);
+        var weights = new List<decimal>();
+        for (int i = 0; i < 50; i++)
+        {
+            weights.Add(Math.Round(75.0m + (decimal)(random.NextDouble() * 2 - 1), 2));
+        }
+        var measurements = weights
+            .Select((w, i) => (new DateTime(2024, 1, 1).AddDays(i).ToString("yyyy-MM-dd"), "08:00:00", w, (decimal?)null))
+            .ToArray();
+        var sourceData = CreateTestSourceData(measurements);
+
+        // Act
+        var result = _sut.ComputeMeasurements(sourceData, CreateTestProfile());
+
+        // Assert: matches the default Hacker's Diet EMA computed independently
+        decimal trend = 0m;
+        for (int i = 0; i < weights.Count; i++)
+        {
+            trend = i == 0 ? weights[i] : trend + 0.1m * (weights[i] - trend);
+            result[i].TrendWeight.Should().Be(Math.Round(trend, 3));
+        }
+    }
+
+    [Fact]
+    public void ComputeMeasurements_WithHoltPresetAndSteadyLoss_TracksCloserThanDefault()
+    {
+        // Arrange: a perfectly steady loss of 0.2 kg/day for 60 days
+        var measurements = Enumerable.Range(0, 60)
+            .Select(i => (new DateTime(2024, 1, 1).AddDays(i).ToString("yyyy-MM-dd"), "08:00:00", 90.0m - 0.2m * i, (decimal?)null))
+            .ToArray();
+        var sourceData = CreateTestSourceData(measurements);
+
+        // Act
+        var defaultResult = _sut.ComputeMeasurements(sourceData, CreateTestProfile());
+        var holtResult = _sut.ComputeMeasurements(sourceData, CreateTestProfile(trendAlgorithm: "holt"));
+
+        // Assert: the default EMA settles into a steady-state lag of slope * (1 - alpha) / alpha
+        // (~1.8 kg here); Holt's slope state largely eliminates it (it can slightly overshoot,
+        // so compare lag magnitudes)
+        var actual = defaultResult[^1].ActualWeight;
+        var defaultLag = defaultResult[^1].TrendWeight - actual;
+        var holtLag = Math.Abs(holtResult[^1].TrendWeight - actual);
+
+        defaultLag.Should().BeGreaterThan(1.5m);
+        holtLag.Should().BeLessThan(0.5m);
+    }
+
+    [Fact]
+    public void ComputeMeasurements_WithHoltPresetAndGaps_SmoothsInterpolatedSeries()
+    {
+        // Arrange: a 3-day gap between readings; interpolation fills days 2 and 3
+        var profile = CreateTestProfile(trendAlgorithm: "holt");
+        var sourceData = CreateTestSourceData(
+            ("2024-01-01", "08:00:00", 70.0m, null),
+            ("2024-01-04", "08:00:00", 73.0m, null)
+        );
+
+        // Act
+        var result = _sut.ComputeMeasurements(sourceData, profile);
+
+        // Assert: interpolated weights are 71.0 and 72.0; Holt runs over the contiguous series
+        result.Should().HaveCount(4);
+        result[1].WeightIsInterpolated.Should().BeTrue();
+        result[2].WeightIsInterpolated.Should().BeTrue();
+
+        // level0 = 70.0, slope = 0
+        // day 2: level = 70.0 + 0.1 * (71.0 - 70.0) = 70.1, slope = 0.01
+        // day 3: forecast = 70.11, level = 70.11 + 0.1 * (72.0 - 70.11) = 70.299, slope = 0.01 + 0.1 * (70.299 - 70.1 - 0.01) = 0.0289
+        // day 4: forecast = 70.3279, level = 70.3279 + 0.1 * (73.0 - 70.3279) = 70.59511 -> 70.595
+        result[0].TrendWeight.Should().Be(70.0m);
+        result[1].TrendWeight.Should().Be(70.1m);
+        result[2].TrendWeight.Should().Be(70.299m);
+        result[3].TrendWeight.Should().Be(70.595m);
     }
 
     #endregion

--- a/apps/api/TrendWeight.Tests/Features/Measurements/TrendAlgorithmPresetsTests.cs
+++ b/apps/api/TrendWeight.Tests/Features/Measurements/TrendAlgorithmPresetsTests.cs
@@ -1,0 +1,61 @@
+using FluentAssertions;
+using TrendWeight.Features.Measurements;
+using Xunit;
+
+namespace TrendWeight.Tests.Features.Measurements;
+
+public class TrendAlgorithmPresetsTests
+{
+    [Fact]
+    public void Resolve_WithNull_ReturnsDefaultPreset()
+    {
+        var preset = TrendAlgorithmPresets.Resolve(null);
+
+        preset.Id.Should().Be(TrendAlgorithmPresets.DefaultId);
+        preset.Alpha.Should().Be(0.1m);
+        preset.Beta.Should().Be(0m);
+    }
+
+    [Fact]
+    public void Resolve_WithUnknownId_FallsBackToDefault()
+    {
+        var preset = TrendAlgorithmPresets.Resolve("some-future-algorithm");
+
+        preset.Id.Should().Be(TrendAlgorithmPresets.DefaultId);
+    }
+
+    [Theory]
+    [InlineData("default")]
+    [InlineData("holt-gentle")]
+    [InlineData("holt")]
+    [InlineData("holt-responsive")]
+    public void Resolve_WithKnownId_ReturnsThatPreset(string id)
+    {
+        var preset = TrendAlgorithmPresets.Resolve(id);
+
+        preset.Id.Should().Be(id);
+    }
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData("default", true)]
+    [InlineData("holt-gentle", true)]
+    [InlineData("holt", true)]
+    [InlineData("holt-responsive", true)]
+    [InlineData("", false)]
+    [InlineData("bogus", false)]
+    public void IsValid_ReturnsExpectedResult(string? id, bool expected)
+    {
+        TrendAlgorithmPresets.IsValid(id).Should().Be(expected);
+    }
+
+    [Fact]
+    public void DefaultPreset_HasZeroBeta()
+    {
+        // Beta = 0 with a zero-initialized slope is what makes the default preset
+        // bit-identical to the original single-EMA implementation
+        var preset = TrendAlgorithmPresets.All.Single(p => p.Id == TrendAlgorithmPresets.DefaultId);
+
+        preset.Beta.Should().Be(0m);
+    }
+}

--- a/apps/api/TrendWeight.Tests/Features/Profile/Controllers/ProfileControllerTests.cs
+++ b/apps/api/TrendWeight.Tests/Features/Profile/Controllers/ProfileControllerTests.cs
@@ -382,6 +382,46 @@ public class ProfileControllerTests : TestBase
     }
 
     [Fact]
+    public async Task UpdateProfile_WithInvalidTrendAlgorithm_ReturnsBadRequest()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        SetupAuthenticatedUser(userId.ToString(), "test@example.com");
+        var request = new UpdateProfileRequest { TrendAlgorithm = "not-a-real-preset" };
+
+        // Act
+        var result = await _sut.UpdateProfile(request);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>()
+            .Which.Value.Should().BeOfType<ErrorResponse>()
+            .Which.Error.Should().Be("Invalid trend algorithm");
+        _profileServiceMock.Verify(x => x.UpdateOrCreateProfileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<UpdateProfileRequest>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateProfile_WithValidTrendAlgorithm_ReturnsResolvedId()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var request = new UpdateProfileRequest { TrendAlgorithm = "holt" };
+        var updatedProfile = CreateTestProfile(userId);
+        updatedProfile.Profile.TrendAlgorithm = "holt";
+
+        SetupAuthenticatedUser(userId.ToString(), "test@example.com");
+        _profileServiceMock.Setup(x => x.UpdateOrCreateProfileAsync(userId.ToString(), "test@example.com", request))
+            .ReturnsAsync(updatedProfile);
+
+        // Act
+        var result = await _sut.UpdateProfile(request);
+
+        // Assert
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var response = okResult.Value.Should().BeOfType<ProfileResponse>().Subject;
+        response.User.TrendAlgorithm.Should().Be("holt");
+    }
+
+    [Fact]
     public async Task UpdateProfile_WithNoUserIdClaim_ReturnsUnauthorized()
     {
         // Arrange

--- a/apps/api/TrendWeight.Tests/Features/Profile/Services/ProfileServiceTests.cs
+++ b/apps/api/TrendWeight.Tests/Features/Profile/Services/ProfileServiceTests.cs
@@ -214,6 +214,78 @@ public class ProfileServiceTests : TestBase
     }
 
     [Fact]
+    public async Task UpdateOrCreateProfileAsync_WithTrendAlgorithm_StoresValue()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var email = "test@example.com";
+        var existingProfile = CreateTestProfile(userId);
+        var request = new UpdateProfileRequest { TrendAlgorithm = "holt" };
+
+        _supabaseServiceMock.Setup(x => x.GetByIdAsync<DbProfile>(userId))
+            .ReturnsAsync(existingProfile);
+        _supabaseServiceMock.Setup(x => x.UpdateAsync(It.IsAny<DbProfile>()))
+            .ReturnsAsync((DbProfile p) => p);
+
+        // Act
+        var result = await _sut.UpdateOrCreateProfileAsync(userId.ToString(), email, request);
+
+        // Assert
+        result.Profile.TrendAlgorithm.Should().Be("holt");
+    }
+
+    [Fact]
+    public async Task UpdateOrCreateProfileAsync_WithNullTrendAlgorithm_PreservesExistingValue()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var email = "test@example.com";
+        var existingProfile = CreateTestProfile(userId);
+        existingProfile.Profile.TrendAlgorithm = "holt-gentle";
+        var request = new UpdateProfileRequest { FirstName = "Updated" };
+
+        _supabaseServiceMock.Setup(x => x.GetByIdAsync<DbProfile>(userId))
+            .ReturnsAsync(existingProfile);
+        _supabaseServiceMock.Setup(x => x.UpdateAsync(It.IsAny<DbProfile>()))
+            .ReturnsAsync((DbProfile p) => p);
+
+        // Act
+        var result = await _sut.UpdateOrCreateProfileAsync(userId.ToString(), email, request);
+
+        // Assert
+        result.Profile.TrendAlgorithm.Should().Be("holt-gentle");
+    }
+
+    [Fact]
+    public async Task ProfileData_WhenTrendAlgorithmMissing_DefaultsToNull()
+    {
+        // Arrange: simulating profile JSONB written before this field existed
+        var userId = Guid.NewGuid();
+        var dbProfile = new DbProfile
+        {
+            Uid = userId,
+            Email = "test@example.com",
+            Profile = new ProfileData
+            {
+                FirstName = "Test",
+                UseMetric = false,
+            },
+            CreatedAt = DateTime.UtcNow.ToString("o"),
+            UpdatedAt = DateTime.UtcNow.ToString("o")
+        };
+
+        _supabaseServiceMock.Setup(x => x.GetByIdAsync<DbProfile>(userId))
+            .ReturnsAsync(dbProfile);
+
+        // Act
+        var result = await _sut.GetByIdAsync(userId);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Profile.TrendAlgorithm.Should().BeNull();
+    }
+
+    [Fact]
     public async Task GetBySharingTokenAsync_ReturnsMatchingProfile()
     {
         // Arrange

--- a/apps/api/TrendWeight/Features/Measurements/MeasurementComputationService.cs
+++ b/apps/api/TrendWeight/Features/Measurements/MeasurementComputationService.cs
@@ -34,8 +34,10 @@ public class MeasurementComputationService : IMeasurementComputationService
         // Step 3: Interpolate missing weight measurements
         sourceMeasurements = InterpolateWeightMeasurements(sourceMeasurements);
 
+        var preset = TrendAlgorithmPresets.Resolve(profile.TrendAlgorithm);
+
         // Step 4: Compute weight trends
-        var measurements = ComputeWeightTrends(sourceMeasurements);
+        var measurements = ComputeWeightTrends(sourceMeasurements, preset);
 
         // Step 5: Process fat measurements if available
         var fatSourceMeasurements = FilterAndGroupFatMeasurements(rawData);
@@ -46,7 +48,7 @@ public class MeasurementComputationService : IMeasurementComputationService
             fatSourceMeasurements = InterpolateFatMeasurements(fatSourceMeasurements);
 
             // Step 7: Compute fat trends and update measurements
-            measurements = ComputeFatTrends(fatSourceMeasurements, measurements);
+            measurements = ComputeFatTrends(fatSourceMeasurements, measurements, preset);
         }
 
         return measurements;
@@ -228,32 +230,62 @@ public class MeasurementComputationService : IMeasurementComputationService
     }
 
     /// <summary>
-    /// Trend smoothing factor matching TypeScript implementation
+    /// Exponential smoother shared by all trend series. Implements Holt's linear trend method
+    /// in error-correction form; with Beta = 0 the slope stays exactly 0m and each update is
+    /// the default Hacker's Diet formula, trend + alpha * (value - trend), bit for bit.
     /// </summary>
-    private const decimal TREND_SMOOTHING_FACTOR = 0.1m;
+    private sealed class TrendSmoother
+    {
+        private readonly decimal _alpha;
+        private readonly decimal _beta;
+        private decimal _level;
+        private decimal _slope;
+        private bool _initialized;
+
+        public TrendSmoother(TrendAlgorithmPreset preset)
+        {
+            _alpha = preset.Alpha;
+            _beta = preset.Beta;
+        }
+
+        public decimal Next(decimal value)
+        {
+            if (!_initialized)
+            {
+                _initialized = true;
+                _level = value;
+                _slope = 0m;
+                return _level;
+            }
+
+            var forecast = _level + _slope;
+            var newLevel = forecast + _alpha * (value - forecast);
+
+            // Guarded so the default preset (Beta = 0) never multiplies by 0m, keeping the
+            // decimal representation identical to the original single-EMA implementation.
+            if (_beta != 0m)
+            {
+                _slope += _beta * (newLevel - _level - _slope);
+            }
+
+            _level = newLevel;
+            return _level;
+        }
+    }
 
     /// <summary>
     /// Computes weight trends from source measurements
     /// Port of computeWeightTrends from TypeScript
     /// </summary>
-    private static List<ComputedMeasurement> ComputeWeightTrends(List<SourceMeasurement> sourceMeasurements)
+    private static List<ComputedMeasurement> ComputeWeightTrends(List<SourceMeasurement> sourceMeasurements, TrendAlgorithmPreset preset)
     {
-        decimal trendWeight = 0;
+        var smoother = new TrendSmoother(preset);
         var measurements = new List<ComputedMeasurement>();
 
         for (int i = 0; i < sourceMeasurements.Count; i++)
         {
             var sourceMeasurement = sourceMeasurements[i];
-            var weight = sourceMeasurement.Weight;
-
-            if (i == 0)
-            {
-                trendWeight = weight;
-            }
-            else
-            {
-                trendWeight = trendWeight + TREND_SMOOTHING_FACTOR * (weight - trendWeight);
-            }
+            var trendWeight = smoother.Next(sourceMeasurement.Weight);
 
             measurements.Add(new ComputedMeasurement
             {
@@ -272,14 +304,14 @@ public class MeasurementComputationService : IMeasurementComputationService
     /// Computes fat trends and updates measurements with fat data
     /// Port of computeFatTrends from TypeScript
     /// </summary>
-    private static List<ComputedMeasurement> ComputeFatTrends(List<SourceMeasurement> fatSourceMeasurements, List<ComputedMeasurement> measurements)
+    private static List<ComputedMeasurement> ComputeFatTrends(List<SourceMeasurement> fatSourceMeasurements, List<ComputedMeasurement> measurements, TrendAlgorithmPreset preset)
     {
         var measurementsByDate = measurements.ToDictionary(m => m.Date, m => m);
         var additionalMeasurements = new List<ComputedMeasurement>();
 
-        decimal trendFatRatio = 0;
-        decimal trendFatMass = 0;
-        decimal trendLeanMass = 0;
+        var fatRatioSmoother = new TrendSmoother(preset);
+        var fatMassSmoother = new TrendSmoother(preset);
+        var leanMassSmoother = new TrendSmoother(preset);
 
         for (int i = 0; i < fatSourceMeasurements.Count; i++)
         {
@@ -289,18 +321,9 @@ public class MeasurementComputationService : IMeasurementComputationService
             var fatMass = weight * fatRatio;
             var leanMass = weight * (1 - fatRatio);
 
-            if (i == 0)
-            {
-                trendFatRatio = fatRatio;
-                trendFatMass = fatMass;
-                trendLeanMass = leanMass;
-            }
-            else
-            {
-                trendFatRatio = trendFatRatio + TREND_SMOOTHING_FACTOR * (fatRatio - trendFatRatio);
-                trendFatMass = trendFatMass + TREND_SMOOTHING_FACTOR * (fatMass - trendFatMass);
-                trendLeanMass = trendLeanMass + TREND_SMOOTHING_FACTOR * (leanMass - trendLeanMass);
-            }
+            var trendFatRatio = fatRatioSmoother.Next(fatRatio);
+            var trendFatMass = fatMassSmoother.Next(fatMass);
+            var trendLeanMass = leanMassSmoother.Next(leanMass);
 
             var dateKey = sourceMeasurement.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 

--- a/apps/api/TrendWeight/Features/Measurements/TrendAlgorithmPresets.cs
+++ b/apps/api/TrendWeight/Features/Measurements/TrendAlgorithmPresets.cs
@@ -1,0 +1,42 @@
+namespace TrendWeight.Features.Measurements;
+
+/// <summary>
+/// A named trend-smoothing configuration. Alpha smooths the level (the displayed trend value);
+/// Beta smooths the slope. Beta = 0 with a zero-initialized slope is exactly the default
+/// Hacker's Diet exponentially smoothed moving average.
+/// </summary>
+public sealed record TrendAlgorithmPreset(string Id, decimal Alpha, decimal Beta);
+
+/// <summary>
+/// The fixed set of trend algorithm presets selectable in profile settings.
+/// Preset ids are stored in profile JSONB and must never be renamed; add new ids instead.
+/// </summary>
+public static class TrendAlgorithmPresets
+{
+    public const string DefaultId = "default";
+
+    public static IReadOnlyList<TrendAlgorithmPreset> All { get; } = new List<TrendAlgorithmPreset>
+    {
+        new(DefaultId, Alpha: 0.1m, Beta: 0m),
+        new("holt-gentle", Alpha: 0.1m, Beta: 0.05m),
+        new("holt", Alpha: 0.1m, Beta: 0.1m),
+        new("holt-responsive", Alpha: 0.15m, Beta: 0.15m),
+    };
+
+    /// <summary>
+    /// Resolves a stored preset id to a preset. Null, empty, or unknown ids fall back to the
+    /// default preset so profiles written by future versions still compute sensibly.
+    /// </summary>
+    public static TrendAlgorithmPreset Resolve(string? id)
+    {
+        return All.FirstOrDefault(p => p.Id == id) ?? All[0];
+    }
+
+    /// <summary>
+    /// Whether an id is acceptable in a profile update. Null is valid and means the default.
+    /// </summary>
+    public static bool IsValid(string? id)
+    {
+        return id == null || All.Any(p => p.Id == id);
+    }
+}

--- a/apps/api/TrendWeight/Features/Profile/Models/ProfileData.cs
+++ b/apps/api/TrendWeight/Features/Profile/Models/ProfileData.cs
@@ -18,6 +18,7 @@ public class ProfileData
     public bool IsMigrated { get; set; }
     public bool IsNewlyMigrated { get; set; }
     public bool HideDataBeforeStart { get; set; }
+    public string? TrendAlgorithm { get; set; }
     public string? ApiKeyHash { get; set; }
     public string? ApiKeySuffix { get; set; }
     public string? ApiKeyCreatedAt { get; set; }

--- a/apps/api/TrendWeight/Features/Profile/Models/ProfileResponses.cs
+++ b/apps/api/TrendWeight/Features/Profile/Models/ProfileResponses.cs
@@ -23,6 +23,7 @@ public class UserProfileData
     public bool UseMetric { get; set; }
     public bool ShowCalories { get; set; }
     public bool HideDataBeforeStart { get; set; }
+    public string TrendAlgorithm { get; set; } = string.Empty;
     public bool SharingEnabled { get; set; }
     public string? SharingToken { get; set; }
     public bool IsMigrated { get; set; }

--- a/apps/api/TrendWeight/Features/Profile/Models/UpdateProfileRequest.cs
+++ b/apps/api/TrendWeight/Features/Profile/Models/UpdateProfileRequest.cs
@@ -10,4 +10,5 @@ public class UpdateProfileRequest
     public bool? UseMetric { get; set; }
     public bool? ShowCalories { get; set; }
     public bool? HideDataBeforeStart { get; set; }
+    public string? TrendAlgorithm { get; set; }
 }

--- a/apps/api/TrendWeight/Features/Profile/ProfileController.cs
+++ b/apps/api/TrendWeight/Features/Profile/ProfileController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using System.Globalization;
 using System.Security.Claims;
 using TrendWeight.Common.Models;
+using TrendWeight.Features.Measurements;
 using TrendWeight.Features.Profile.Models;
 using TrendWeight.Features.Profile.Services;
 using TrendWeight.Infrastructure.DataAccess;
@@ -151,6 +152,7 @@ public class ProfileController : ControllerBase
                 UseMetric = user.Profile.UseMetric,
                 ShowCalories = user.Profile.ShowCalories ?? false,
                 HideDataBeforeStart = user.Profile.HideDataBeforeStart,
+                TrendAlgorithm = TrendAlgorithmPresets.Resolve(user.Profile.TrendAlgorithm).Id,
                 SharingEnabled = user.Profile.SharingEnabled,
                 SharingToken = user.Profile.SharingToken,
                 IsMigrated = user.Profile.IsMigrated,
@@ -192,6 +194,11 @@ public class ProfileController : ControllerBase
             {
                 _logger.LogWarning("Invalid user ID format: {UserId}", userId);
                 return Unauthorized(new ErrorResponse { Error = "Invalid authentication" });
+            }
+
+            if (!TrendAlgorithmPresets.IsValid(request.TrendAlgorithm))
+            {
+                return BadRequest(new ErrorResponse { Error = "Invalid trend algorithm" });
             }
 
             // Use the service to update or create the profile

--- a/apps/api/TrendWeight/Features/Profile/Services/ProfileService.cs
+++ b/apps/api/TrendWeight/Features/Profile/Services/ProfileService.cs
@@ -88,6 +88,7 @@ public class ProfileService : IProfileService
                     DayStartOffset = request.DayStartOffset,
                     ShowCalories = request.ShowCalories,
                     HideDataBeforeStart = request.HideDataBeforeStart ?? false,
+                    TrendAlgorithm = request.TrendAlgorithm,
                     SharingToken = await GenerateUniqueShareTokenAsync()
                 },
                 CreatedAt = DateTime.UtcNow.ToString("o"),
@@ -112,6 +113,7 @@ public class ProfileService : IProfileService
             profile.Profile.UseMetric = request.UseMetric ?? profile.Profile.UseMetric;
             profile.Profile.ShowCalories = request.ShowCalories;
             profile.Profile.HideDataBeforeStart = request.HideDataBeforeStart ?? profile.Profile.HideDataBeforeStart;
+            profile.Profile.TrendAlgorithm = request.TrendAlgorithm ?? profile.Profile.TrendAlgorithm;
 
             // Update email if it's changed
             if (profile.Email != email)

--- a/apps/web/src/components/dashboard/recent-readings.test.tsx
+++ b/apps/web/src/components/dashboard/recent-readings.test.tsx
@@ -67,6 +67,19 @@ describe("RecentReadings", () => {
     expect(screen.getByRole("columnheader", { name: "Trend" })).toBeInTheDocument();
   });
 
+  it("should label the trend column for an alternate trend algorithm", () => {
+    mockUseDashboardData.mockReturnValue({
+      dataPoints: mockDataPoints,
+      mode: ["weight", vi.fn()],
+      profile: { useMetric: false, trendAlgorithm: "holt" },
+    } as any);
+
+    render(<RecentReadings />);
+
+    expect(screen.getByRole("columnheader", { name: "Trend (Holt)" })).toBeInTheDocument();
+    expect(screen.queryByRole("columnheader", { name: "Trend" })).not.toBeInTheDocument();
+  });
+
   it("should render all data points", () => {
     render(<RecentReadings />);
 

--- a/apps/web/src/components/dashboard/recent-readings.tsx
+++ b/apps/web/src/components/dashboard/recent-readings.tsx
@@ -1,6 +1,7 @@
 import { recentDate } from "@/lib/core/dates";
 import { Modes } from "@/lib/core/interfaces";
 import { formatMeasurement } from "@/lib/core/numbers";
+import { getTrendLabel } from "@/lib/core/trend-algorithms";
 import { useDashboardData } from "@/lib/dashboard/hooks";
 import { Heading } from "@/components/common/heading";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
@@ -9,7 +10,7 @@ const RecentReadings = () => {
   const {
     dataPoints,
     mode: [mode],
-    profile: { useMetric },
+    profile: { useMetric, trendAlgorithm },
   } = useDashboardData();
 
   const readings = dataPoints.slice(-14).reverse();
@@ -23,7 +24,7 @@ const RecentReadings = () => {
             <TableRow>
               <TableHead className="pl-0 text-left">Date</TableHead>
               <TableHead className="text-right">Actual</TableHead>
-              <TableHead className="pr-0 text-right">Trend</TableHead>
+              <TableHead className="pr-0 text-right">{getTrendLabel(trendAlgorithm)}</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>

--- a/apps/web/src/components/math/math-of-trendweight.md
+++ b/apps/web/src/components/math/math-of-trendweight.md
@@ -279,6 +279,53 @@ This linear interpolation ensures:
 - No artificial jumps in the data
 - Reasonable estimates for missing measurements
 
+## Alternate Trend Algorithms
+
+TrendWeight's default formula comes straight from [The Hacker's Diet](https://www.fourmilab.ch/hackdiet/) by John Walker — specifically its ["Signal and Noise" chapter](https://www.fourmilab.ch/hackdiet/e4/signalnoise.html), which introduced exponential smoothing as a way to find the real trend hiding in noisy daily weights.
+
+### Why the Default Formula Lags on Purpose
+
+The default formula has a quirk: when your weight follows a steady slope (as it does during consistent dieting), the trend line lags behind your actual weight. With $\alpha = 0.1$, the steady-state lag works out to about 9 days' worth of weight change — lose 2 pounds a week and the trend line reads roughly 2.6 pounds heavier than your smoothed "true" weight.
+
+That lag is a feature, not a bug. The Hacker's Diet describes daily weights as "floats" and "sinkers" relative to the trend line — the same imagery used on your dashboard chart. Because the trend lags during weight loss, most daily readings land _below_ the line, acting as sinkers that pull it down. Even a discouraging overnight jump usually still sits under the trend line, so it reads as continued progress rather than failure. Walker argued this framing keeps the day-to-day noise of the scale motivating instead of demoralizing.
+
+### Holt's Linear Trend Method
+
+If you'd rather have a trend line that tracks steady weight loss more closely, the Advanced Settings offer presets based on Holt's linear trend method (also called double exponential smoothing). Where the default formula tracks one quantity (the smoothed weight, or _level_), Holt's method also tracks a second one (the smoothed _slope_):
+
+$$L_t = \alpha X_t + (1-\alpha)(L_{t-1} + b_{t-1})$$
+
+$$b_t = \beta (L_t - L_{t-1}) + (1-\beta) b_{t-1}$$
+
+Where:
+
+- $L_t$ = Level (the displayed trend value) at time $t$
+- $b_t$ = Slope (the smoothed rate of change) at time $t$
+- $\alpha$ = Level smoothing factor
+- $\beta$ = Slope smoothing factor
+
+Each day, the method first predicts where your weight should be ($L_{t-1} + b_{t-1}$), then nudges that prediction toward the actual reading. Because it carries a slope estimate forward, it follows a steady decline with almost no lag.
+
+The default formula is actually a special case: set $\beta = 0$ (and start the slope at zero) and Holt's method reduces exactly to the exponential smoothing described above. That's how the setting works internally — every preset runs the same algorithm with different constants:
+
+| Preset                  | $\alpha$ | $\beta$ | Character                                                 |
+| ----------------------- | -------- | ------- | --------------------------------------------------------- |
+| Default (Hacker's Diet) | 0.1      | 0       | Deliberate lag; steady and predictable                    |
+| Holt (gentle)           | 0.1      | 0.05    | Familiar smoothness with slow slope tracking              |
+| Holt (standard)         | 0.1      | 0.1     | Balanced; follows steady loss with much less lag          |
+| Holt (responsive)       | 0.15     | 0.15    | Adapts fastest to direction changes, with a wigglier line |
+
+### The Tradeoff
+
+Holt's method isn't simply "better" — it trades one behavior for another:
+
+- **Less lag during steady loss**: the trend line hugs your actual weight instead of trailing days behind it.
+- **Weaker "sinker" effect**: because the line sits closer to your daily weights, roughly half your readings will land above it even while you're losing. You give up some of the psychological cushion the default formula provides.
+- **Overshoot at turning points**: the slope estimate has momentum. When a steady loss ends in a plateau, the trend line briefly dips below your actual weight before catching up.
+- **Every derived number follows the line**: the weekly rate, calorie estimates, goal projections, and time comparisons are all calculated from the trend values, so they change along with the algorithm. Your actual scale readings are never affected.
+
+If any of that sounds like a downside rather than a curiosity, just leave the setting off.
+
 ## Conclusion
 
 TrendWeight transforms the emotional rollercoaster of daily weighing into a mathematically sound feedback system. By applying exponential smoothing, linear regression, and careful statistical analysis, it reveals the true signal hiding in the noise of daily weight fluctuations.

--- a/apps/web/src/components/settings/advanced-section.test.tsx
+++ b/apps/web/src/components/settings/advanced-section.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useForm } from "react-hook-form";
+import { AdvancedSection } from "./advanced-section";
+import type { ProfileData } from "@/lib/core/interfaces";
+
+// Mock router components
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, to, ...props }: any) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+// Test wrapper component
+function TestWrapper({ defaultValues = {} }: { defaultValues?: Partial<ProfileData> }) {
+  const { register, control, watch, setValue, formState } = useForm<ProfileData>({
+    defaultValues,
+  });
+
+  return (
+    <>
+      <AdvancedSection register={register} errors={formState.errors} watch={watch} setValue={setValue} control={control} />
+      <div data-testid="form-value">{watch("trendAlgorithm") ?? ""}</div>
+      <div data-testid="form-dirty">{formState.isDirty ? "dirty" : "clean"}</div>
+    </>
+  );
+}
+
+describe("AdvancedSection trend algorithm setting", () => {
+  it("renders the switch off with no algorithm dropdown by default", () => {
+    render(<TestWrapper defaultValues={{ trendAlgorithm: "default" }} />);
+
+    expect(screen.getByText("Use an alternate trend algorithm")).toBeInTheDocument();
+    expect(screen.queryByText("Holt (standard)")).not.toBeInTheDocument();
+  });
+
+  it("shows concise help copy when off and the full explanation when on", () => {
+    render(<TestWrapper defaultValues={{ trendAlgorithm: "default" }} />);
+
+    expect(screen.getByText(/entirely optional and generally not needed/)).toBeInTheDocument();
+    expect(screen.queryByText(/The Hacker's Diet argues/)).not.toBeInTheDocument();
+
+    const switches = screen.getAllByRole("switch");
+    fireEvent.click(switches[switches.length - 1]);
+
+    expect(screen.queryByText(/entirely optional and generally not needed/)).not.toBeInTheDocument();
+    expect(screen.getByText(/The Hacker's Diet argues/)).toBeInTheDocument();
+  });
+
+  it("treats a missing trendAlgorithm as the default", () => {
+    render(<TestWrapper />);
+
+    expect(screen.queryByText("Holt (standard)")).not.toBeInTheDocument();
+  });
+
+  it("reveals the dropdown preset to Holt (standard) when toggled on", () => {
+    render(<TestWrapper defaultValues={{ trendAlgorithm: "default" }} />);
+
+    const switches = screen.getAllByRole("switch");
+    fireEvent.click(switches[switches.length - 1]); // trend algorithm switch is the last one
+
+    expect(screen.getByTestId("form-value")).toHaveTextContent("holt");
+    expect(screen.getByText("Holt (standard)")).toBeInTheDocument();
+    expect(screen.getByTestId("form-dirty")).toHaveTextContent("dirty");
+  });
+
+  it("shows the dropdown when a Holt preset is already selected", () => {
+    render(<TestWrapper defaultValues={{ trendAlgorithm: "holt-gentle" }} />);
+
+    expect(screen.getByText("Holt (gentle)")).toBeInTheDocument();
+  });
+
+  it("reverts to the default when toggled off", () => {
+    render(<TestWrapper defaultValues={{ trendAlgorithm: "holt" }} />);
+
+    const switches = screen.getAllByRole("switch");
+    fireEvent.click(switches[switches.length - 1]);
+
+    expect(screen.getByTestId("form-value")).toHaveTextContent("default");
+    expect(screen.queryByText("Holt (standard)")).not.toBeInTheDocument();
+  });
+
+  it("links to the math page section", () => {
+    render(<TestWrapper defaultValues={{ trendAlgorithm: "default" }} />);
+
+    expect(screen.getByRole("link", { name: /learn more about the math/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/settings/advanced-section.tsx
+++ b/apps/web/src/components/settings/advanced-section.tsx
@@ -1,6 +1,8 @@
 import type { Control, FieldErrors, UseFormRegister, UseFormSetValue, UseFormWatch } from "react-hook-form";
 import { Controller } from "react-hook-form";
+import { Link } from "@tanstack/react-router";
 import type { ProfileData } from "@/lib/core/interfaces";
+import { TREND_ALGORITHM_DEFAULT, TREND_ALGORITHMS } from "@/lib/core/trend-algorithms";
 import { CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
@@ -19,7 +21,10 @@ const dayStartOptions = Array.from({ length: 24 }, (_, i) => {
   return { value: hour, label: displayHour };
 });
 
-export function AdvancedSection({ control }: AdvancedSectionProps) {
+export function AdvancedSection({ control, watch, setValue }: AdvancedSectionProps) {
+  const trendAlgorithm = watch("trendAlgorithm");
+  const alternateTrendOn = !!trendAlgorithm && trendAlgorithm !== TREND_ALGORITHM_DEFAULT;
+
   return (
     <>
       <CardHeader className="pt-6">
@@ -91,6 +96,77 @@ export function AdvancedSection({ control }: AdvancedSectionProps) {
             )}
           />
           <p className="text-muted-foreground mt-2 text-sm">Display estimated calorie surplus/deficit based on your weight changes.</p>
+        </div>
+
+        <div className="mt-6">
+          <div className="flex items-start space-x-3">
+            <div className="flex-shrink-0">
+              <Switch
+                checked={alternateTrendOn}
+                onCheckedChange={(checked) => {
+                  setValue("trendAlgorithm", checked ? "holt" : TREND_ALGORITHM_DEFAULT, { shouldDirty: true });
+                }}
+              />
+            </div>
+            <label className="cursor-pointer">
+              <div className="text-foreground/80 text-sm font-medium">Use an alternate trend algorithm</div>
+            </label>
+          </div>
+          {alternateTrendOn && (
+            <div className="mt-3">
+              <Controller
+                name="trendAlgorithm"
+                control={control}
+                render={({ field }) => (
+                  <Select value={field.value ?? ""} onValueChange={field.onChange}>
+                    <SelectTrigger className="w-full md:w-64">
+                      <SelectValue placeholder="Select algorithm..." />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {TREND_ALGORITHMS.filter((a) => !a.isDefault).map((algorithm) => (
+                        <SelectItem key={algorithm.id} value={algorithm.id}>
+                          {algorithm.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </div>
+          )}
+          <div className="text-muted-foreground mt-2 space-y-2 text-sm">
+            {alternateTrendOn ? (
+              <>
+                <p>
+                  The default formula deliberately lags behind your actual weight. While you're losing, most daily readings land below the trend line, which The
+                  Hacker's Diet argues keeps day-to-day noise motivating instead of discouraging. Alternate algorithms (variants of Holt's linear trend method)
+                  follow steady weight loss with less lag, but give up some of that effect. Your actual scale readings are untouched, but the trend line and
+                  everything calculated from it — weekly rate, calorie estimates, and goal projections — will change.{" "}
+                  <Link to="/math" hash="alternate-trend-algorithms" className="text-link hover:text-link underline">
+                    Learn more about the math
+                  </Link>
+                  .
+                </p>
+                <ul className="list-disc space-y-1 pl-5">
+                  {TREND_ALGORITHMS.filter((a) => !a.isDefault).map((algorithm) => (
+                    <li key={algorithm.id}>
+                      <span className="font-medium">{algorithm.name}:</span> {algorithm.description}
+                    </li>
+                  ))}
+                </ul>
+                <p className="font-medium">If you're not sure what to do with this setting, just leave it off.</p>
+              </>
+            ) : (
+              <p>
+                TrendWeight can optionally use an alternate formula to calculate your trend line. This is entirely optional and generally not needed — the
+                default formula works well for most people.{" "}
+                <Link to="/math" hash="alternate-trend-algorithms" className="text-link hover:text-link underline">
+                  Learn more about the math
+                </Link>
+                .
+              </p>
+            )}
+          </div>
         </div>
       </CardContent>
     </>

--- a/apps/web/src/components/settings/settings.test.tsx
+++ b/apps/web/src/components/settings/settings.test.tsx
@@ -18,6 +18,7 @@ const mockProfileData = {
   goalStart: "2024-01-01",
   dayStartOffset: 0,
   showCalories: false,
+  hideDataBeforeStart: false,
   sharingEnabled: true,
   sharingToken: "abc123",
 };
@@ -150,6 +151,31 @@ describe("Settings", () => {
       expect(screen.getByTestId("goal-start")).toHaveValue("2024-01-01");
       expect(screen.getByTestId("planned-rate")).toHaveValue(1.0);
     });
+  });
+
+  it("should return to a clean state when a change is reverted and optional fields are unset", async () => {
+    // Regression: with goalStart/goalWeight unset, the empty date input holds "" and the
+    // empty valueAsNumber input holds NaN. Unless hydration normalizes the defaults to
+    // match, react-hook-form's isDirty deep-compare sticks dirty forever after any edit.
+    const original = { ...mockProfileData };
+    delete (mockProfileData as Partial<typeof mockProfileData>).goalStart;
+    delete (mockProfileData as Partial<typeof mockProfileData>).goalWeight;
+    try {
+      const user = userEvent.setup();
+      render(<Settings />);
+
+      const checkbox = screen.getByTestId("show-calories");
+      await user.click(checkbox); // change
+      expect(screen.getByText("You have unsaved changes")).toBeInTheDocument();
+
+      await user.click(checkbox); // revert
+      await waitFor(() => {
+        expect(screen.queryByText("You have unsaved changes")).not.toBeInTheDocument();
+        expect(screen.getByText("Save Settings")).toBeDisabled();
+      });
+    } finally {
+      Object.assign(mockProfileData, original);
+    }
   });
 
   it("should show unsaved changes message when form is dirty", async () => {

--- a/apps/web/src/components/settings/settings.tsx
+++ b/apps/web/src/components/settings/settings.tsx
@@ -19,6 +19,16 @@ import { ProgressTrackingSection } from "./progress-tracking-section";
 import { SettingsLayout } from "./settings-layout";
 import { SharingSection } from "./sharing-section";
 
+// Normalizes API profile data into the values the registered inputs actually hold, so
+// react-hook-form's isDirty deep-compare doesn't see phantom differences: an empty date
+// input reads "" (never undefined), and an empty valueAsNumber input reads NaN. The
+// submit handler maps these back ("" / NaN -> undefined) before calling the API.
+const toFormValues = (data: ProfileData): ProfileData => ({
+  ...data,
+  goalStart: data.goalStart ?? "",
+  goalWeight: data.goalWeight ?? NaN,
+});
+
 export function Settings() {
   const { data: profileData } = useProfile();
   const updateProfile = useUpdateProfile();
@@ -37,7 +47,7 @@ export function Settings() {
   // Update form when profile data loads
   useEffect(() => {
     if (profileData) {
-      reset(profileData);
+      reset(toFormValues(profileData));
     }
   }, [profileData, reset]);
 
@@ -96,7 +106,7 @@ export function Settings() {
 
       const response = await updateProfile.mutateAsync(cleanedData);
       // Reset form state with the actual response data to mark as clean
-      reset(response.user);
+      reset(toFormValues(response.user));
     } catch (error) {
       console.error("Failed to update settings:", error);
     }

--- a/apps/web/src/lib/api/mutations.ts
+++ b/apps/web/src/lib/api/mutations.ts
@@ -14,6 +14,7 @@ interface UpdateProfileData {
   useMetric?: boolean;
   showCalories?: boolean;
   hideDataBeforeStart?: boolean;
+  trendAlgorithm?: string;
 }
 
 export function useUpdateProfile() {
@@ -40,6 +41,9 @@ export function useUpdateProfile() {
       queryClient.setQueryData(queryKeys.profile(), data);
       // Invalidate to ensure fresh data
       queryClient.invalidateQueries({ queryKey: queryKeys.profile() });
+      // Settings like dayStartOffset and trendAlgorithm change the server-computed
+      // measurements, so refresh those too
+      queryClient.invalidateQueries({ queryKey: queryKeys.allData() });
     },
   });
 }

--- a/apps/web/src/lib/api/queries.ts
+++ b/apps/web/src/lib/api/queries.ts
@@ -65,6 +65,7 @@ const selectProfileData = (data: ProfileResponse | null): ProfileData | null => 
     useMetric: data.user.useMetric,
     showCalories: data.user.showCalories,
     hideDataBeforeStart: data.user.hideDataBeforeStart,
+    trendAlgorithm: data.user.trendAlgorithm,
     sharingToken: data.user.sharingToken,
     sharingEnabled: data.user.sharingEnabled,
     isMigrated: data.user.isMigrated,

--- a/apps/web/src/lib/core/interfaces.ts
+++ b/apps/web/src/lib/core/interfaces.ts
@@ -38,6 +38,7 @@ export interface ProfileData {
   isMigrated?: boolean;
   isNewlyMigrated?: boolean;
   hideDataBeforeStart?: boolean;
+  trendAlgorithm?: string;
 }
 
 export interface SharingData {

--- a/apps/web/src/lib/core/trend-algorithms.test.ts
+++ b/apps/web/src/lib/core/trend-algorithms.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { TREND_ALGORITHM_DEFAULT, TREND_ALGORITHMS, getTrendLabel, resolveTrendAlgorithm } from "./trend-algorithms";
+
+describe("trend-algorithms", () => {
+  describe("resolveTrendAlgorithm", () => {
+    it("returns the default preset for undefined", () => {
+      expect(resolveTrendAlgorithm(undefined).id).toBe(TREND_ALGORITHM_DEFAULT);
+    });
+
+    it("returns the default preset for null", () => {
+      expect(resolveTrendAlgorithm(null).id).toBe(TREND_ALGORITHM_DEFAULT);
+    });
+
+    it("returns the default preset for an unknown id", () => {
+      expect(resolveTrendAlgorithm("some-future-algorithm").id).toBe(TREND_ALGORITHM_DEFAULT);
+    });
+
+    it("returns the matching algorithm for known ids", () => {
+      for (const algorithm of TREND_ALGORITHMS) {
+        expect(resolveTrendAlgorithm(algorithm.id)).toBe(algorithm);
+      }
+    });
+  });
+
+  describe("getTrendLabel", () => {
+    it("returns 'Trend' for the default", () => {
+      expect(getTrendLabel(undefined)).toBe("Trend");
+      expect(getTrendLabel(TREND_ALGORITHM_DEFAULT)).toBe("Trend");
+    });
+
+    it("returns a Holt label for Holt presets", () => {
+      expect(getTrendLabel("holt")).toBe("Trend (Holt)");
+      expect(getTrendLabel("holt-gentle")).toBe("Trend (Holt)");
+      expect(getTrendLabel("holt-responsive")).toBe("Trend (Holt)");
+    });
+  });
+
+  it("has exactly one default algorithm, listed first", () => {
+    expect(TREND_ALGORITHMS.filter((a) => a.isDefault)).toHaveLength(1);
+    expect(TREND_ALGORITHMS[0].id).toBe(TREND_ALGORITHM_DEFAULT);
+  });
+});

--- a/apps/web/src/lib/core/trend-algorithms.ts
+++ b/apps/web/src/lib/core/trend-algorithms.ts
@@ -1,0 +1,49 @@
+export const TREND_ALGORITHM_DEFAULT = "default";
+
+export interface TrendAlgorithmInfo {
+  id: string;
+  name: string;
+  description: string;
+  trendLabel: string;
+  isDefault: boolean;
+}
+
+// Ids must match TrendAlgorithmPresets on the backend and are stored in profiles — never rename.
+export const TREND_ALGORITHMS: TrendAlgorithmInfo[] = [
+  {
+    id: TREND_ALGORITHM_DEFAULT,
+    name: "Default (Hacker's Diet)",
+    description: "The original exponentially smoothed moving average.",
+    trendLabel: "Trend",
+    isDefault: true,
+  },
+  {
+    id: "holt-gentle",
+    name: "Holt (gentle)",
+    description: "Adds slow slope tracking to the default formula, keeping its familiar smoothness.",
+    trendLabel: "Trend (Holt)",
+    isDefault: false,
+  },
+  {
+    id: "holt",
+    name: "Holt (standard)",
+    description: "Balanced slope tracking that follows steady weight loss with much less lag.",
+    trendLabel: "Trend (Holt)",
+    isDefault: false,
+  },
+  {
+    id: "holt-responsive",
+    name: "Holt (responsive)",
+    description: "Adapts fastest to changes in direction, at the cost of a wigglier line.",
+    trendLabel: "Trend (Holt)",
+    isDefault: false,
+  },
+];
+
+export function resolveTrendAlgorithm(id?: string | null): TrendAlgorithmInfo {
+  return TREND_ALGORITHMS.find((a) => a.id === id) ?? TREND_ALGORITHMS[0];
+}
+
+export function getTrendLabel(id?: string | null): string {
+  return resolveTrendAlgorithm(id).trendLabel;
+}

--- a/apps/web/src/lib/dashboard/chart/create-chart-series.test.ts
+++ b/apps/web/src/lib/dashboard/chart/create-chart-series.test.ts
@@ -22,7 +22,7 @@ describe("create-chart-series", () => {
 
   describe("createTrendSeries", () => {
     it("should create trend series with correct properties", () => {
-      const series = createTrendSeries(sampleData, "weight", "Weight", false);
+      const series = createTrendSeries(sampleData, "weight", "Weight", false, "Trend");
 
       expect(series.type).toBe("line");
       expect(series.id).toBe("trend");
@@ -36,10 +36,10 @@ describe("create-chart-series", () => {
     });
 
     it("should use different colors for different modes", () => {
-      const weightSeries = createTrendSeries(sampleData, "weight", "Weight", false);
-      const fatPercentSeries = createTrendSeries(sampleData, "fatpercent", "Fat %", false);
-      const fatMassSeries = createTrendSeries(sampleData, "fatmass", "Fat Mass", false);
-      const leanMassSeries = createTrendSeries(sampleData, "leanmass", "Lean Mass", false);
+      const weightSeries = createTrendSeries(sampleData, "weight", "Weight", false, "Trend");
+      const fatPercentSeries = createTrendSeries(sampleData, "fatpercent", "Fat %", false, "Trend");
+      const fatMassSeries = createTrendSeries(sampleData, "fatmass", "Fat Mass", false, "Trend");
+      const leanMassSeries = createTrendSeries(sampleData, "leanmass", "Lean Mass", false, "Trend");
 
       expect(weightSeries.color).toBe("var(--chart-weight)");
       expect(fatPercentSeries.color).toBe("var(--chart-fatpercent)");
@@ -48,18 +48,24 @@ describe("create-chart-series", () => {
     });
 
     it("should adjust line width for narrow displays", () => {
-      const normalSeries = createTrendSeries(sampleData, "weight", "Weight", false);
-      const narrowSeries = createTrendSeries(sampleData, "weight", "Weight", true);
+      const normalSeries = createTrendSeries(sampleData, "weight", "Weight", false, "Trend");
+      const narrowSeries = createTrendSeries(sampleData, "weight", "Weight", true, "Trend");
 
       expect(normalSeries.lineWidth).toBe(2);
       expect(narrowSeries.lineWidth).toBe(1.5);
     });
 
     it("should prevent legend item clicks", () => {
-      const series = createTrendSeries(sampleData, "weight", "Weight", false);
+      const series = createTrendSeries(sampleData, "weight", "Weight", false, "Trend");
 
       expect(series.events?.legendItemClick).toBeDefined();
       expect(typeof series.events?.legendItemClick).toBe("function");
+    });
+
+    it("should use the provided trend label in the series name", () => {
+      const series = createTrendSeries(sampleData, "weight", "Weight", false, "Trend (Holt)");
+
+      expect(series.name).toBe("Weight Trend (Holt)");
     });
   });
 
@@ -206,7 +212,7 @@ describe("create-chart-series", () => {
 
   describe("color consistency", () => {
     it("should use same colors across trend and projection series", () => {
-      const trendSeries = createTrendSeries(sampleData, "leanmass", "Lean Mass", false);
+      const trendSeries = createTrendSeries(sampleData, "leanmass", "Lean Mass", false, "Trend");
       const projectionSeries = createProjectionSeries(sampleData, "leanmass", "Lean Mass", false);
 
       expect(trendSeries.color).toBe(projectionSeries.color);
@@ -217,7 +223,7 @@ describe("create-chart-series", () => {
   describe("z-index layering", () => {
     it("should have correct z-index hierarchy", () => {
       const diamondsSeries = createDiamondsSeries(sampleDataWithNulls, false, false);
-      const trendSeries = createTrendSeries(sampleData, "weight", "Weight", false);
+      const trendSeries = createTrendSeries(sampleData, "weight", "Weight", false, "Trend");
       const dotSeries = createDotSeries(sampleDataWithNulls, false);
       const lineSeries = createLineSeries(sampleDataWithNulls, false);
       const sinkersSeries = createSinkersSeries(sampleSinkersData, false);

--- a/apps/web/src/lib/dashboard/chart/create-chart-series.ts
+++ b/apps/web/src/lib/dashboard/chart/create-chart-series.ts
@@ -8,12 +8,12 @@ const getColors = () => ({
   leanmass: "var(--chart-leanmass)",
 });
 
-export const createTrendSeries = (data: [number, number][], mode: Mode, modeText: string, isNarrow: boolean): SeriesLineOptions => {
+export const createTrendSeries = (data: [number, number][], mode: Mode, modeText: string, isNarrow: boolean, trendLabel: string): SeriesLineOptions => {
   const colors = getColors();
   return {
     type: "line",
     id: "trend",
-    name: `${modeText} Trend`,
+    name: `${modeText} ${trendLabel}`,
     data,
     color: colors[mode],
     lineWidth: isNarrow ? 1.5 : 2,

--- a/apps/web/src/lib/dashboard/chart/option-builders.test.ts
+++ b/apps/web/src/lib/dashboard/chart/option-builders.test.ts
@@ -23,6 +23,7 @@ describe("option-builders", () => {
   const createBuilderOptions = () => ({
     mode: "weight" as const,
     modeText: "Weight",
+    trendLabel: "Trend",
     isNarrow: false,
     lastMeasurement: {
       date: LocalDate.of(2024, 1, 15),

--- a/apps/web/src/lib/dashboard/chart/option-builders.ts
+++ b/apps/web/src/lib/dashboard/chart/option-builders.ts
@@ -17,6 +17,7 @@ interface ChartDataArrays {
 interface BuilderOptions {
   mode: keyof typeof Modes;
   modeText: string;
+  trendLabel: string;
   isNarrow: boolean;
   lastMeasurement: { date: LocalDate; trend: number };
   dataArrays: ChartDataArrays;
@@ -46,11 +47,11 @@ export function buildWeekendPlotBands(lastMeasurementDate: LocalDate): XAxisOpti
 }
 
 export function build4WeekOptions(options: Options, builderOptions: BuilderOptions): void {
-  const { mode, modeText, isNarrow, lastMeasurement, dataArrays } = builderOptions;
+  const { mode, modeText, trendLabel, isNarrow, lastMeasurement, dataArrays } = builderOptions;
   const { actualData, interpolatedData, trendData, projectionsData, actualSinkersData, interpolatedSinkersData } = dataArrays;
 
   if (options.series && options.xAxis && !Array.isArray(options.xAxis)) {
-    options.series.push(createTrendSeries(trendData, mode, modeText, isNarrow));
+    options.series.push(createTrendSeries(trendData, mode, modeText, isNarrow, trendLabel));
     options.series.push(createDiamondsSeries(actualData, false, isNarrow));
     options.series.push(createDiamondsSeries(interpolatedData, true, isNarrow));
     options.series.push(createSinkersSeries(actualSinkersData, false));
@@ -64,11 +65,11 @@ export function build4WeekOptions(options: Options, builderOptions: BuilderOptio
 }
 
 export function build3MonthOptions(options: Options, builderOptions: BuilderOptions): void {
-  const { mode, modeText, isNarrow, dataArrays } = builderOptions;
+  const { mode, modeText, trendLabel, isNarrow, dataArrays } = builderOptions;
   const { actualData, interpolatedData, trendData, projectionsData, actualSinkersData, interpolatedSinkersData } = dataArrays;
 
   if (options.series && options.xAxis && !Array.isArray(options.xAxis)) {
-    options.series.push(createTrendSeries(trendData, mode, modeText, isNarrow));
+    options.series.push(createTrendSeries(trendData, mode, modeText, isNarrow, trendLabel));
 
     if (isNarrow) {
       options.series.push(createLineSeries(actualData, false));
@@ -87,12 +88,12 @@ export function build3MonthOptions(options: Options, builderOptions: BuilderOpti
 }
 
 export function buildLongTermOptions(options: Options, builderOptions: BuilderOptions, timeRange: "6m" | "1y" | "all"): void {
-  const { mode, modeText, isNarrow, dataArrays } = builderOptions;
+  const { mode, modeText, trendLabel, isNarrow, dataArrays } = builderOptions;
   const { actualData, trendData, projectionsData } = dataArrays;
 
   if (options.series && options.xAxis && !Array.isArray(options.xAxis)) {
     options.series = [];
-    options.series.push(createTrendSeries(trendData, mode, modeText, isNarrow));
+    options.series.push(createTrendSeries(trendData, mode, modeText, isNarrow, trendLabel));
     options.series.push(createLineSeries(actualData, false));
     options.series.push(createProjectionSeries(projectionsData, mode, modeText, isNarrow));
 
@@ -103,13 +104,13 @@ export function buildLongTermOptions(options: Options, builderOptions: BuilderOp
 }
 
 export function buildExploreOptions(options: Options, builderOptions: BuilderOptions): void {
-  const { mode, modeText, isNarrow, lastMeasurement, dataArrays } = builderOptions;
+  const { mode, modeText, trendLabel, isNarrow, lastMeasurement, dataArrays } = builderOptions;
   const { actualData, interpolatedData, trendData, projectionsData, actualSinkersData, interpolatedSinkersData } = dataArrays;
 
   if (options.series && options.xAxis && !Array.isArray(options.xAxis)) {
     // Initial series setup
     options.series = [];
-    options.series.push(createTrendSeries(trendData, mode, modeText, isNarrow));
+    options.series.push(createTrendSeries(trendData, mode, modeText, isNarrow, trendLabel));
 
     if (isNarrow) {
       options.series.push(createLineSeries(actualData, false));

--- a/apps/web/src/lib/dashboard/chart/use-chart-options.ts
+++ b/apps/web/src/lib/dashboard/chart/use-chart-options.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { Modes } from "@/lib/core/interfaces";
+import { getTrendLabel } from "@/lib/core/trend-algorithms";
 import { useIsMobile } from "@/lib/hooks/use-media-query";
 import type { DashboardData } from "@/lib/dashboard/dashboard-context";
 import { transformChartData } from "./data-transformers";
@@ -14,7 +15,7 @@ export const useChartOptions = (data: DashboardData, heightOverride?: string) =>
     mode: [mode],
     timeRange: [timeRange],
     activeSlope,
-    profile: { useMetric, goalWeight },
+    profile: { useMetric, goalWeight, trendAlgorithm },
   } = data;
 
   return useMemo(() => {
@@ -37,6 +38,7 @@ export const useChartOptions = (data: DashboardData, heightOverride?: string) =>
     const builderOptions = {
       mode,
       modeText,
+      trendLabel: getTrendLabel(trendAlgorithm),
       isNarrow,
       lastMeasurement,
       dataArrays,
@@ -68,5 +70,5 @@ export const useChartOptions = (data: DashboardData, heightOverride?: string) =>
     buildYAxisOptions(options, mode, useMetric, goalWeight);
 
     return options;
-  }, [dataPoints, activeSlope, goalWeight, isNarrow, mode, timeRange, useMetric, heightOverride]);
+  }, [dataPoints, activeSlope, goalWeight, isNarrow, mode, timeRange, useMetric, trendAlgorithm, heightOverride]);
 };


### PR DESCRIPTION
Implements #396: optional pre-defined presets based on Holt's linear trend method (double exponential smoothing) as alternatives to the default Hacker's Diet EMA.

## What's here

- **Unified smoother**: one (alpha, beta) code path; the default preset (0.1, 0) is bit-identical to the current formula — beta = 0 with a zero-initialized slope reduces exactly to `trend += 0.1 * (weight - trend)`. All 441 pre-existing computation tests pass untouched.
- **Presets, not sliders**: `default`, `holt-gentle` (0.1/0.05), `holt` (0.1/0.1), `holt-responsive` (0.15/0.15). Stored as `TrendAlgorithm` in profile JSONB (no migration); unknown ids resolve to the default, invalid ids get a 400 on update.
- **Settings UX with deliberate friction**: a switch in Advanced Settings reveals the preset dropdown; concise help copy when off, full explanation (including that derived stats change) when on. Links to a new "Alternate Trend Algorithms" section on the math page.
- **Dashboard labeling**: chart legend and Recent Readings header read "Trend (Holt)" when a non-default preset is active. CSV headers stay stable. All series (weight, fat %, fat mass, lean mass) use the same algorithm.
- **Fixes along the way**: profile saves now invalidate the dashboard data query (trend/day-start changes show immediately), and the settings form no longer stays dirty after a reverted change when goal start/weight are unset.

## Testing

- Backend: 467 tests (26 new — hand-computed Holt sequences, exact default-equivalence over pseudo-random series, fat trends, gaps, preset registry, profile round-trips, controller validation)
- Frontend: 955 tests (new coverage for the label helper, settings switch/dropdown behavior, chart series naming, readings header, dirty-state regression)
- Manually verified end-to-end on the dev server with seeded steady-loss data: label changes, immediate refresh, Holt hugging actuals vs the classic ~9-day lag, and byte-identical numbers after reverting to the default.

Closes #396