### PR TITLE
fix(docker): build and run the API on the .NET 10 images

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,6 +22,17 @@
       "allowedVersions": "<7.0.0"
     },
     {
+      "description": "The dotnet images must match the API's TargetFramework (net10.0): the 11.0 tag currently carries RC builds and even at GA a net10.0 app cannot start on an 11.0 runtime image. Lift this together with the net11.0 TargetFramework bump.",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "mcr.microsoft.com/dotnet/sdk",
+        "mcr.microsoft.com/dotnet/aspnet"
+      ],
+      "allowedVersions": "<11"
+    },
+    {
       "description": "Require publication timestamps for npm and NuGet cooldown checks",
       "matchDatasources": [
         "npm",

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ WORKDIR /app/apps/web
 RUN npm run build
 
 # Stage 2: Build backend
-FROM mcr.microsoft.com/dotnet/sdk:11.0@sha256:86afb5e989113ab0c32f04002635ff1c6fe0620cbb8ca0e22d2db1e151384a3f AS backend-build
+FROM mcr.microsoft.com/dotnet/sdk:10.0@sha256:4beef5b8919dcaa2dc924233bd069257e883cc7a061e09088a97d152d6a48510 AS backend-build
 
 WORKDIR /src
 
@@ -59,7 +59,7 @@ RUN dotnet restore TrendWeight.sln --locked-mode
 RUN dotnet publish TrendWeight/TrendWeight.csproj --no-restore -c Release -o /app/publish
 
 # Stage 3: Runtime
-FROM mcr.microsoft.com/dotnet/aspnet:11.0@sha256:656770db703ebbc4f5115104095573677d9a21a906fcccc16393d18ea949a49f AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:10.0@sha256:011bb5f30180717b1c8b65822ff2c99bcb96bc65af0164589751b83c7b4949f7 AS runtime
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Restore the \`mcr.microsoft.com/dotnet/sdk:10.0\` and \`aspnet:10.0\` base images. #478 moved them to the \`11.0\` tag, which currently ships only the .NET 11 RC1 runtime (\`dotnet --list-runtimes\` in that image shows \`11.0.0-rc.1\` only). The API targets net10.0 and .NET does not roll forward across majors, so the container exited immediately at startup and DigitalOcean reported the staging deploy as "Container Terminated".
- Add a Renovate rule pinning both dotnet images to \`<11\` so the image major only moves together with the API's TargetFramework. Digest and minor updates for 10.0 keep flowing.

## Verification
- The CI Docker Build validates the image builds; the runtime failure only shows up when the container starts, which CI does not exercise.